### PR TITLE
Fusionner les branches de code

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -31,10 +31,12 @@ export default function Home() {
   const handleSubmit = async (
     v: Omit<EstimateParams, 'currentPrice'> & { currentPrice?: number },
   ) => {
+    console.log('🔍 [DEBUG] Form submitted with values:', v);
     setLoading(true);
     setResults(null);
 
     const p: EstimateParams = { ...v, currentPrice: v.currentPrice ?? 0 };
+    console.log('🔍 [DEBUG] Final EstimateParams:', p);
     setParams(p);
 
     try {

--- a/src/components/EstimatorForm.tsx
+++ b/src/components/EstimatorForm.tsx
@@ -26,8 +26,15 @@ const formSchema = z.object({
   address: z.string().optional(),
   bedrooms: z.coerce.number().int().positive({ message: "Le nombre de chambres doit être positif." }).optional(),
   currentPrice: z.coerce.number().positive({ message: "Le tarif actuel doit être positif." }).optional(), // Made optional
-}).refine(data => !!data.airbnbUrl || (!!data.address && !!data.bedrooms), {
-  message: "⚠️ Merci de compléter les champs obligatoires.",
+}).refine(data => {
+  const hasAirbnbUrl = !!data.airbnbUrl && data.airbnbUrl.trim() !== '';
+  const hasAddress = !!data.address && data.address.trim() !== '';
+  console.log('🔍 [DEBUG] Validation refine - hasAirbnbUrl:', hasAirbnbUrl);
+  console.log('🔍 [DEBUG] Validation refine - hasAddress:', hasAddress);
+  console.log('🔍 [DEBUG] Validation refine - data:', data);
+  return hasAirbnbUrl || hasAddress; // Allow either Airbnb URL OR just address (bedrooms not mandatory)
+}, {
+  message: "⚠️ Merci de remplir soit l'URL Airbnb soit l'adresse.",
   path: ["airbnbUrl"], // Attach error message to airbnbUrl field visually, though it applies globally
 });
 
@@ -61,6 +68,10 @@ const EstimatorForm: React.FC<EstimatorFormProps> = ({ onSubmit, isLoading }) =>
 
   // Simplified submit handler - just calls the passed onSubmit
   const handleFormSubmit: SubmitHandler<EstimatorFormValues> = (data) => {
+      console.log('🔍 [DEBUG] Form handleFormSubmit called with:', data);
+      console.log('🔍 [DEBUG] Form data.address:', data.address);
+      console.log('🔍 [DEBUG] Form data.airbnbUrl:', data.airbnbUrl);
+      console.log('🔍 [DEBUG] Form data.bedrooms:', data.bedrooms);
       onSubmit(data);
   };
 

--- a/src/services/vdc-solutions.ts
+++ b/src/services/vdc-solutions.ts
@@ -98,7 +98,10 @@ export interface EstimateResult {
  * @returns A promise that resolves to an EstimateResult object, or null if no comparable properties are found.
  */
 export async function estimateProperty(params: EstimateParams): Promise<EstimateResult | null> {
-  console.log('Calling estimateProperty with params:', params);
+  console.log('🔍 [DEBUG] Calling estimateProperty with params:', params);
+  console.log('🔍 [DEBUG] params.address:', params.address);
+  console.log('🔍 [DEBUG] params.airbnbUrl:', params.airbnbUrl);
+  console.log('🔍 [DEBUG] params.bedrooms:', params.bedrooms);
 
   try {
     // Construire l'URL de l'API Cloudflare
@@ -106,8 +109,13 @@ export async function estimateProperty(params: EstimateParams): Promise<Estimate
     
     // Ajouter les paramètres requis
     if (params.address) {
+      console.log('🔍 [DEBUG] Using address:', params.address);
       apiUrl.searchParams.set('address', params.address);
+    } else if (params.airbnbUrl) {
+      console.log('🔍 [DEBUG] AirbnbUrl provided but no address extraction logic!');
+      throw new Error('Address extraction from Airbnb URL not implemented yet');
     } else {
+      console.log('🔍 [DEBUG] Neither address nor airbnbUrl provided');
       throw new Error('Address is required');
     }
     
@@ -115,7 +123,7 @@ export async function estimateProperty(params: EstimateParams): Promise<Estimate
     const adults = params.bedrooms ? Math.max(2, params.bedrooms * 2) : 2;
     apiUrl.searchParams.set('adults', adults.toString());
 
-    console.log('Calling Cloudflare API:', apiUrl.toString());
+    console.log('🔍 [DEBUG] Final API URL:', apiUrl.toString());
 
     // Appel à l'API Cloudflare
     const response = await fetch(apiUrl.toString(), {


### PR DESCRIPTION
Fix form validation to allow address-only submissions and improve API parameter handling.

The previous form validation schema (`EstimatorForm.tsx`) incorrectly required both `address` and `bedrooms` to be filled if no `airbnbUrl` was provided, preventing valid address-only submissions. Additionally, the `estimateProperty` function (`vdc-solutions.ts`) was updated to explicitly handle cases where an `airbnbUrl` is provided without address extraction logic. Debug logs were added across the form, page, and service for better traceability.